### PR TITLE
Allow undefined symbols on StreetmapRuntime plugin

### DIFF
--- a/Source/StreetMapRuntime/StreetMapRuntime.Build.cs
+++ b/Source/StreetMapRuntime/StreetMapRuntime.Build.cs
@@ -24,6 +24,7 @@ namespace UnrealBuildTool.Rules
       );
 
       PrivateIncludePaths.AddRange(new string[]{"StreetMapRuntime/Private"});
+  		bIgnoreUnresolvedSymbols=true;
     }
   }
 }


### PR DESCRIPTION
this change is required to allow the corresponsing branch in carla to work properly