### PR TITLE
Extraction of simple signs from the OSM data

### DIFF
--- a/Source/StreetMapImporting/Private/OSMFile.cpp
+++ b/Source/StreetMapImporting/Private/OSMFile.cpp
@@ -120,6 +120,13 @@ bool FOSMFile::ProcessElement( const TCHAR* ElementName, const TCHAR* ElementDat
 			ParsingState = ParsingState::Way_Tag;
 		}
 	}
+	else if (ParsingState == ParsingState::Node)
+	{
+		if( !FCString::Stricmp( ElementName, TEXT( "tag" ) ) )
+		{
+			ParsingState = ParsingState::Node_Tag;
+		}
+	}
 
 	return true;
 }
@@ -367,6 +374,25 @@ bool FOSMFile::ProcessAttribute( const TCHAR* AttributeName, const TCHAR* Attrib
 			}
 		}
 	}
+	else if(ParsingState == ParsingState::Node_Tag)
+	{
+		if( !FCString::Stricmp( AttributeName, TEXT( "k" ) ) )
+		{
+			CurrentNodeTagKey = AttributeValue;
+		}
+		else if( !FCString::Stricmp( AttributeName, TEXT( "v" ) ) )
+		{
+			if( !FCString::Stricmp( CurrentNodeTagKey, TEXT( "highway" ) )  ||
+				!FCString::Stricmp( CurrentNodeTagKey, TEXT( "traffic_sign" ) ))
+			{
+				CurrentNodeInfo->Type = AttributeValue;
+			}
+			else if ( !FCString::Stricmp( CurrentNodeTagKey, TEXT( "maxspeed" ) ) )
+			{
+				CurrentNodeInfo->MaxSpeed = FPlatformString::Atoi64(AttributeValue);
+			}
+		}
+	}
 
 	return true;
 }
@@ -397,6 +423,11 @@ bool FOSMFile::ProcessClose( const TCHAR* Element )
 	{
 		CurrentWayTagKey = TEXT( "" );
 		ParsingState = ParsingState::Way;
+	}
+	else if (ParsingState == ParsingState::Node_Tag)
+	{
+		CurrentNodeTagKey = TEXT("");
+		ParsingState = ParsingState::Node;
 	}
 
 	return true;

--- a/Source/StreetMapImporting/Private/StreetMapFactory.cpp
+++ b/Source/StreetMapImporting/Private/StreetMapFactory.cpp
@@ -398,7 +398,7 @@ bool UStreetMapFactory::LoadFromOpenStreetMapXMLFile( UStreetMap* StreetMap, FSt
 			}
 		}
 	
-		//Adding Sings
+		//Adding Signs
 		if(!OSMNode.Type.IsEmpty())
 		{
 			FStreetMapSign& NewSign = *new( StreetMap->Signs )FStreetMapSign();

--- a/Source/StreetMapImporting/Private/StreetMapFactory.cpp
+++ b/Source/StreetMapImporting/Private/StreetMapFactory.cpp
@@ -397,6 +397,16 @@ bool UStreetMapFactory::LoadFromOpenStreetMapXMLFile( UStreetMap* StreetMap, FSt
 				// Node doesn't reference any roads that we kept, or the data was malformed.  Filter it out.
 			}
 		}
+	
+		//Adding Sings
+		if(!OSMNode.Type.IsEmpty())
+		{
+			FStreetMapSign& NewSign = *new( StreetMap->Signs )FStreetMapSign();
+			NewSign.OSM_ID = NodeMapHashPair.Key;
+			NewSign.Position = GetTransversemercProjection(OSMNode.Latitude, OSMNode.Longitude, NewLatLonOrigin.X, NewLatLonOrigin.Y);
+			NewSign.SignValue = OSMNode.Type;
+			NewSign.MaxSpeed = OSMNode.MaxSpeed;
+		}
 	}
 
 	// Validation test: Make sure that all roads have at least two nodes referencing them, one at the beginning and

--- a/Source/StreetMapImporting/Public/OSMFile.h
+++ b/Source/StreetMapImporting/Public/OSMFile.h
@@ -155,6 +155,8 @@ public:
 		double Latitude;
 		double Longitude;
 		TArray<FOSMWayRef> WayRefs;
+		FString Type;
+		int MaxSpeed;
 	};
 		
 		
@@ -206,7 +208,8 @@ protected:
 		Node,
 		Way,
 		Way_NodeRef,
-		Way_Tag
+		Way_Tag,
+		Node_Tag
 	};
 		
 	// Current state of parser
@@ -223,6 +226,9 @@ protected:
 		
 	// Current way's tag key string
 	const TCHAR* CurrentWayTagKey;
+
+	// Current way's tag key string
+	const TCHAR* CurrentNodeTagKey;
 };
 
 

--- a/Source/StreetMapImporting/Public/OSMFile.h
+++ b/Source/StreetMapImporting/Public/OSMFile.h
@@ -139,6 +139,16 @@ public:
 		Other,
 	};
 
+	enum class EOSSignType 
+	{
+		Crossing,
+		Max_Speed,
+		Traffic_Lights,
+		Give_Way,
+		Stop,
+		Bus_Stop,
+		Other,
+	};
 
 	struct FOSMWayRef
 	{
@@ -156,6 +166,7 @@ public:
 		double Longitude;
 		TArray<FOSMWayRef> WayRefs;
 		FString Type;
+		//EOSSignType;
 		int MaxSpeed;
 	};
 		

--- a/Source/StreetMapRuntime/Public/StreetMap.h
+++ b/Source/StreetMapRuntime/Public/StreetMap.h
@@ -306,6 +306,29 @@ struct STREETMAPRUNTIME_API FStreetMapBuilding
 	FVector2D BoundsMax;
 };
 
+/** A sign */
+USTRUCT( BlueprintType )
+struct STREETMAPRUNTIME_API FStreetMapSign
+{
+	GENERATED_USTRUCT_BODY()
+
+	/** Name of the building */
+	UPROPERTY( Category=StreetMap, EditAnywhere, BlueprintReadWrite )
+	double OSM_ID;
+
+	/** Category of the sign */
+	UPROPERTY( Category=StreetMap, EditAnywhere, BlueprintReadWrite )
+	FString SignValue;
+
+	UPROPERTY(Category = StreetMap, EditAnywhere, BlueprintReadWrite)
+	int MaxSpeed;
+
+	/** 2D lat/lon position of the sign */
+	UPROPERTY( Category=StreetMap, EditAnywhere, BlueprintReadWrite )
+	FVector2D Position;
+
+};
+
 
 /** A loaded street map */
 UCLASS( Blueprintable, BlueprintType )
@@ -357,6 +380,17 @@ public:
 		return Buildings;
 	}
 
+	const TArray<FStreetMapSign>& GetSigns() const
+	{
+		return Signs;
+	}
+
+	/** Gets all of the signs */
+	TArray<FStreetMapSign>& GetSigns()
+	{
+		return Signs;
+	}
+
 	/** Gets the bounding box of the map */
 	FVector2D GetBoundsMin() const
 	{
@@ -381,6 +415,10 @@ protected:
 	/** List of all buildings on the street map */
 	UPROPERTY( Category=StreetMap, VisibleAnywhere, BlueprintReadOnly )
 	TArray<FStreetMapBuilding> Buildings;
+
+	/** List of all signs on the street map */
+	UPROPERTY( Category=StreetMap, VisibleAnywhere, BlueprintReadOnly )
+	TArray<FStreetMapSign> Signs;
 
 	/** 2D bounds (min) of this map's roads and buildings */
 	UPROPERTY( Category=StreetMap, VisibleAnywhere)


### PR DESCRIPTION
Adding a new Array accessible from UE5 editor to further support the creation of signs according to OSM data.

Key data extracted at the moment is the OSM ID, sign type and position converted to UE coordinates.