### PR TITLE
fix: add missing includes for editor-only sources under non-unity builds

### DIFF
--- a/Source/StreetMapImporting/Private/StreetMapComponentDetails.cpp
+++ b/Source/StreetMapImporting/Private/StreetMapComponentDetails.cpp
@@ -3,6 +3,7 @@
 #include "StreetMapComponentDetails.h"
 #include "StreetMapImporting.h"
 
+#include "AssetToolsModule.h"
 #include "SlateBasics.h"
 #include "RawMesh.h"
 #include "PropertyEditorModule.h"

--- a/Source/StreetMapImporting/Private/StreetMapImportBlueprintLibrary.cpp
+++ b/Source/StreetMapImporting/Private/StreetMapImportBlueprintLibrary.cpp
@@ -7,6 +7,8 @@
 #include "StreetMapImportBlueprintLibrary.h"
 #include "StreetMapFactory.h"
 #include "StreetMap.h"
+#include "StreetMapImporting.h"
+#include "AssetToolsModule.h"
 #include "Engine/AssetManager.h"
 
 #if ENGINE_MAJOR_VERSION > 4


### PR DESCRIPTION
#### Description

Two `StreetMapImporting` sources relied on transitive includes pulled in by neighboring `.cpp` files in their unity blob, so they fail to compile when the consumer disables unity (e.g. CARLA's UE5 build under `bUseUnityBuild=false`).

Errors observed under unity off:

```
StreetMapImporting/Private/StreetMapImportBlueprintLibrary.cpp:35
  use of undeclared identifier 'LogStreetMapImporting'
StreetMapImporting/Private/StreetMapImportBlueprintLibrary.cpp:47
  unknown type name 'IAssetTools'
  use of undeclared identifier 'FAssetToolsModule'
StreetMapImporting/Private/StreetMapComponentDetails.cpp:221
  unknown type name 'FAssetToolsModule'
```

Fix by adding the headers that already supply those identifiers:

- `StreetMapImportBlueprintLibrary.cpp`: add `StreetMapImporting.h` (for the `LogStreetMapImporting` log category declared in the module header) and `AssetToolsModule.h` (for `FAssetToolsModule` and `IAssetTools`).
- `StreetMapComponentDetails.cpp`: add `AssetToolsModule.h`.

Public APIs are unchanged.

Context: filed alongside carla-simulator/carla#9763 / carla-simulator/carla#9764, which fix the matching IWYU issues in CARLA's own Carla and CarlaTools plugins.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 24.04, x86_64
  * **Unreal Engine version(s):** 5.5 (CARLA fork)
  * **Consumer:** CARLA `carla-unreal-editor` cmake target with `bUseUnityBuild=false` — built green to completion after this patch.

#### Possible Drawbacks

None expected; only adds explicit includes.

#### Impact on CI / default settings & local ccache motivation

No CI impact (CI runs with `bUseUnityBuild=true`, under which these includes are no-ops). The CI-effect analysis and the local ccache hit-rate measurement that motivated this fix are in the CARLA companion PR — see carla-simulator/carla#9764.
